### PR TITLE
Fix disabling optional alarms

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -67,7 +67,7 @@ MonitorAlarmMetric: &monitor_alarm_metric
         - title: Every 12 hours
           const: PT12H
         - title: Every 24 hours
-          const: PT1D
+          const: P1D
     aggregation:
       title: Aggregation
       description: The aggregation type of the alarm.

--- a/src/monitoring.tf
+++ b/src/monitoring.tf
@@ -22,7 +22,9 @@ locals {
     "DISABLED"  = {}
     "CUSTOM"    = lookup(var.monitoring, "alarms", {})
   }
-  alarms = lookup(local.alarms_map, var.monitoring.mode, {})
+  alarms             = lookup(local.alarms_map, var.monitoring.mode, {})
+  monitoring_enabled = var.monitoring.mode != "DISABLED" ? 1 : 0
+
 }
 
 module "alarm_channel" {
@@ -32,6 +34,7 @@ module "alarm_channel" {
 }
 
 module "normalized_ru_consumption_metric_alert" {
+  count                   = local.monitoring_enabled
   source                  = "github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm?ref=40d6e54"
   scopes                  = [azurerm_cosmosdb_account.main.id]
   resource_group_name     = azurerm_resource_group.main.name
@@ -57,6 +60,7 @@ module "normalized_ru_consumption_metric_alert" {
 }
 
 module "server_latency_metric_alert" {
+  count                   = local.monitoring_enabled
   source                  = "github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm?ref=40d6e54"
   scopes                  = [azurerm_cosmosdb_account.main.id]
   resource_group_name     = azurerm_resource_group.main.name


### PR DESCRIPTION
closes: https://github.com/massdriver-cloud/azure-cosmosdb-mongo/issues/26

Tested locally and in personal org