### PR TITLE
Fix for mongo network issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,49 @@ Resources created by this bundle that can be connected to other bundles.
           - **`cluster_id`** *(string)*
           - **`project_id`** *(string)*
   - **`specs`** *(object)*
+    - **`aws`** *(object)*: .
+      - **`region`** *(string)*: AWS Region to provision in.
+
+        Examples:
+        ```json
+        "us-west-2"
+        ```
+
+    - **`azure`** *(object)*: .
+      - **`region`** *(string)*: Select the Azure region you'd like to provision your resources in.
+    - **`gcp`** *(object)*: .
+      - **`project`** *(string)*
+      - **`region`** *(string)*: The GCP region to provision resources in.
+
+        Examples:
+        ```json
+        "us-east1"
+        ```
+
+        ```json
+        "us-east4"
+        ```
+
+        ```json
+        "us-west1"
+        ```
+
+        ```json
+        "us-west2"
+        ```
+
+        ```json
+        "us-west3"
+        ```
+
+        ```json
+        "us-west4"
+        ```
+
+        ```json
+        "us-central1"
+        ```
+
     - **`mongo`** *(object)*: Informs downstream bundles of Mongo specific data. Cannot contain additional properties.
       - **`version`** *(string)*: Currently deployed Mongo version.
 <!-- ARTIFACTS:END -->

--- a/operator.mdx
+++ b/operator.mdx
@@ -1,6 +1,12 @@
 # azure-cosmosdb-mongo
 Azure Cosmos DB is a fully managed NoSQL and relational database for modern app development. Azure Cosmos DB offers single-digit millisecond response times, automatic and instant scalability, along with guarantee speed at any scale. Business continuity is assured with SLA-backed availability and enterprise-grade security.
 
+## Cosmos DB Network issue workaround
+There is a known network issue with the Cosmos DB Mongo bundle that refuses network connections with other resources in the same virtual network. Microsoft is aware of the issue and is working on a fix. In the meantime, you can use the following workaround to allow network connections between your Cosmos DB instance and other resources in your virtual network:
+1. [Fork the bundle](https://docs.massdriver.cloud/extend-the-platform/fork-the-bundle) to your own organization.
+2. Update `public_network_access_enabled` on line 44 of `main.tf` to `true`.
+3. Using the Mass CLI, [publish](https://docs.massdriver.cloud/cli/overview#bundles) the bundle to your organization.
+
 ## Use Cases 
 As a fully managed service, Azure Cosmos DB takes database administration off your hands with automatic management, updates and patching. It also handles capacity management with cost-effective serverless and automatic scaling options that respond to application needs to match capacity with demand.
 ### Cloud applications

--- a/operator.mdx
+++ b/operator.mdx
@@ -7,7 +7,7 @@ There is a known network issue with the Cosmos DB Mongo bundle that refuses netw
 2. Update `public_network_access_enabled` on line 44 of `main.tf` to `true`.
 3. Using the Mass CLI, [publish](https://docs.massdriver.cloud/cli/overview#bundles) the bundle to your organization.
 
-## Use Cases 
+## Use Cases
 As a fully managed service, Azure Cosmos DB takes database administration off your hands with automatic management, updates and patching. It also handles capacity management with cost-effective serverless and automatic scaling options that respond to application needs to match capacity with demand.
 ### Cloud applications
 Web, mobile, gaming, and IoT application that handle massive amounts of data, reads, and writes at a global scale with near-real response times for various data will benefit from Azure Cosmos DB. Azure Cosmos DB's guaranteed high availability, high throughput, low latency, and tunable consistency are huge advantages when building these types of applications.
@@ -22,7 +22,7 @@ The API for MongoDB has added benefits of being built on Azure Cosmos DB when co
 * Cost efficient
 * Serverless deployments
 
-## Configuration Presets 
+## Configuration Presets
 ### Development
 The development preset uses the serverless feature of Azure Cosmos DB. Azure Cosmos DB serverless best fits scenarios where you expect intermittent and unpredictable traffic with long idle times. Because provisioning capacity in such situations isn't required and may be cost-prohibitive, Azure Cosmos DB serverless is recommended for developing, testing, prototyping, and running in production new apps where the traffic pattern is unknown.
 ### Production
@@ -32,7 +32,7 @@ The production preset uses the provisioned feature of Azure Cosmos DB. When you 
 ### Auto CIDR
 The Masssdriver Auto CIDR feature takes the burden of selecting a CIDR range away from you by determining the next available CIDR range and automatically provisions it. You still have the option to manually set your CIDR range if you prefer.
 
-## Design 
+## Design
 Our bundle includes the following design choices to help simplify your deployment:
 ### Geo-Redundancy
 Various geo-redundancy options are available when deploying a Cosmos DB instance, such as multi-region writes and automatic failover.
@@ -46,8 +46,8 @@ We automatically provision a dedicated virtual network subnet with its own priva
 ### Automated backups
 Azure Cosmos DB automatically takes backups of your data at regular intervals. The automatic backups are taken without affecting the performance or availability of the database operations. All the backups are stored separately in a storage service.
 
-## Security 
-In order to improve security, we implement a few key safeguards. 
+## Security
+In order to improve security, we implement a few key safeguards.
 ### Private subnet deployment
 The flexible server will be accessible only from within the private VNet and any peered networks.
 ### Data encrypted in transit
@@ -55,9 +55,9 @@ By default, all data in transit will be encrypted with Secure Sockets Layer and 
 ### Data encrypted at rest
 Encryption at rest is now available for documents and backups stored in Azure Cosmos DB in all Azure regions. Encryption at rest is applied automatically for both new and existing customers in these regions. There's no need to configure anything. You get the same great latency, throughput, availability, and functionality as before with the benefit of knowing your data is safe and secure with encryption at rest. Data stored in your Azure Cosmos DB account is automatically and seamlessly encrypted with keys managed by Microsoft using service-managed keys.
 
-## Observability 
+## Observability
 Massdriver provides you with visibility into the health of your systems. By default, flexible servers will be created with alarms connected to Massdriver to alert you when performance drops below a key threshold or fails completely. You will be notified when the R/U consumption and server latency exceed their respective thresholds.
 
-## Trade-offs 
+## Trade-offs
 * CMKs are not currently supported
 * Cannot change backup types after deployment

--- a/operator.mdx
+++ b/operator.mdx
@@ -1,12 +1,6 @@
 # azure-cosmosdb-mongo
 Azure Cosmos DB is a fully managed NoSQL and relational database for modern app development. Azure Cosmos DB offers single-digit millisecond response times, automatic and instant scalability, along with guarantee speed at any scale. Business continuity is assured with SLA-backed availability and enterprise-grade security.
 
-## Cosmos DB Network issue workaround
-There is a known network issue with the Cosmos DB Mongo bundle that refuses network connections with other resources in the same virtual network. Microsoft is aware of the issue and is working on a fix. In the meantime, you can use the following workaround to allow network connections between your Cosmos DB instance and other resources in your virtual network:
-1. [Fork the bundle](https://docs.massdriver.cloud/extend-the-platform/fork-the-bundle) to your own organization.
-2. Update `public_network_access_enabled` on line 44 of `main.tf` to `true`.
-3. Using the Mass CLI, [publish](https://docs.massdriver.cloud/cli/overview#bundles) the bundle to your organization.
-
 ## Use Cases
 As a fully managed service, Azure Cosmos DB takes database administration off your hands with automatic management, updates and patching. It also handles capacity management with cost-effective serverless and automatic scaling options that respond to application needs to match capacity with demand.
 ### Cloud applications

--- a/src/main.tf
+++ b/src/main.tf
@@ -33,15 +33,16 @@ resource "azurerm_resource_group" "main" {
 }
 
 resource "azurerm_cosmosdb_account" "main" {
-  name                                  = var.md_metadata.name_prefix
-  location                              = azurerm_resource_group.main.location
-  resource_group_name                   = azurerm_resource_group.main.name
-  offer_type                            = "Standard"
-  kind                                  = "MongoDB"
-  enable_automatic_failover             = var.geo_redundancy.automatic_failover
-  enable_multiple_write_locations       = var.geo_redundancy.multi_region_writes
-  mongo_server_version                  = var.database.mongo_server_version
-  public_network_access_enabled         = false
+  name                            = var.md_metadata.name_prefix
+  location                        = azurerm_resource_group.main.location
+  resource_group_name             = azurerm_resource_group.main.name
+  offer_type                      = "Standard"
+  kind                            = "MongoDB"
+  enable_automatic_failover       = var.geo_redundancy.automatic_failover
+  enable_multiple_write_locations = var.geo_redundancy.multi_region_writes
+  mongo_server_version            = var.database.mongo_server_version
+  # With public_network_access_enable = true, plus virtual_network_filter_enabled = true, the CosmosDB account will be accessible from the VNet and not the internet.
+  public_network_access_enabled         = true
   is_virtual_network_filter_enabled     = true
   access_key_metadata_writes_enabled    = false
   network_acl_bypass_for_azure_services = true

--- a/src/subnet.tf
+++ b/src/subnet.tf
@@ -30,3 +30,22 @@ resource "azurerm_subnet" "main" {
   address_prefixes     = [local.cidr]
   service_endpoints    = ["Microsoft.AzureCosmosDB"]
 }
+
+resource "azurerm_private_endpoint" "default" {
+  name                = "${var.md_metadata.name_prefix}-pe"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  subnet_id           = azurerm_subnet.main.id
+
+  private_service_connection {
+    name                           = "${var.md_metadata.name_prefix}-psc"
+    private_connection_resource_id = azurerm_cosmosdb_account.main.id
+    subresource_names              = ["MongoDB"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "privatelink_mongo_cosmos_azure_com"
+    private_dns_zone_ids = ["/subscriptions/${var.azure_service_principal.data.subscription_id}/resourceGroups/${local.vnet_resource_group}/providers/Microsoft.Network/privateDnsZones/privatelink.mongo.cosmos.azure.com"]
+  }
+}


### PR DESCRIPTION
What it looks like when `public_network_access_enabled=true` is set with the other configurations in the bundle:
![image](https://github.com/massdriver-cloud/azure-cosmosdb-mongo/assets/8037512/035131a6-77f0-433d-8d75-eb6f1f0252b4)
Selectively allows the specified VNet instead of all traffic