### PR TITLE
Enable access key writes

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_cosmosdb_account" "main" {
   # With public_network_access_enable = true, plus virtual_network_filter_enabled = true, the CosmosDB account will be accessible from the VNet and not the internet.
   public_network_access_enabled         = true
   is_virtual_network_filter_enabled     = true
-  access_key_metadata_writes_enabled    = false
+  access_key_metadata_writes_enabled    = true
   network_acl_bypass_for_azure_services = true
   tags                                  = var.md_metadata.default_tags
 


### PR DESCRIPTION
Since we aren't using RBAC for Cosmos DB Mongo bundle, and instead using access key (static creds), this bool needs to be enabled to allow apps to do metadata functions like creating collections

https://learn.microsoft.com/en-us/azure/cosmos-db/audit-control-plane-logs